### PR TITLE
magit-log-jump: new function: jump to branch/tag/commit in log buffer

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2616,6 +2616,11 @@ the status buffer.
   first parent, but a numeric prefix can be used to specify another
   parent.
 
+- Key: j, magit-log-jump
+
+  Cursor jump to a given branch, tag or commit. If item does not
+  appear in the current log buffer, do nothing. 
+
 - Key: SPC, magit-diff-show-or-scroll-up
 
   Update the commit or diff buffer for the thing at point.

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -934,6 +934,7 @@ is displayed in the current frame."
     (define-key map "=" 'magit-log-toggle-commit-limit)
     (define-key map "+" 'magit-log-double-commit-limit)
     (define-key map "-" 'magit-log-half-commit-limit)
+    (define-key map "j" 'magit-log-jump)
     (define-key map "q" 'magit-log-bury-buffer)
     map)
   "Keymap for `magit-log-mode'.")
@@ -1418,6 +1419,13 @@ If there is no blob buffer in the same frame, then do nothing."
              (magit-section-match '(commit branch)
                                   magit-previous-section))
     (magit-log-goto-commit-section (oref magit-previous-section value))))
+
+(defun magit-log-jump (rev)
+  (interactive (list (magit-read-other-branch-or-commit "Jump")))
+  (when (string-match "\\`heads/\\(.+\\)" rev)
+    (setq rev (match-string 1 rev)))
+  (unless (magit-log-goto-commit-section rev)
+    (user-error "Commit `%s' does not appear in the log buffer." rev)))
 
 ;;; Log Margin
 


### PR DESCRIPTION
- Function to jump to different locations in a log buffer based on branches, tags (with
  completion) and commits (without completion).

- If the item selected (based on `magit-read-other-branch-or-commit`) does not appear in the log
  buffer, do nothing, notifying the user. Perhaps other function can be used to limit the
  selections only to content in the current log buffer.

- Shortcut was chosen as `j` because in other buffers it's also associated with jumping.

- Documentation updated.